### PR TITLE
[TD-311] 내가 제보한 가게, 리뷰, 방문 목록 조회시, 해당 가게가 삭제되었을 경우 해당 목록에 보이지만 삭제된 가게라고 표시되도록 수정

### DIFF
--- a/threedollar-api/src/main/java/com/depromeet/threedollar/api/controller/review/ReviewController.java
+++ b/threedollar-api/src/main/java/com/depromeet/threedollar/api/controller/review/ReviewController.java
@@ -46,11 +46,24 @@ public class ReviewController {
         return ApiResponse.SUCCESS;
     }
 
-    @ApiOperation("[인증] 마이 페이지 - 내가 작성한 리뷰 목록을 스크롤 페이지네이션으로 조회합니다")
+    @ApiOperation("[인증] 마이 페이지 - 내가 작성한 리뷰 목록을 스크롤 페이지네이션으로 조회합니다 (삭제된 가게 포함 O)")
     @Auth
-    @GetMapping("/api/v2/store/reviews/me")
+    @GetMapping("/api/v3/store/reviews/me")
     public ApiResponse<ReviewScrollResponse> retrieveMyStoreReviews(@Valid RetrieveMyReviewsRequest request, @UserId Long userId) {
         return ApiResponse.success(reviewRetrieveService.retrieveMyReviews(request, userId));
+    }
+
+    /**
+     * v2.1.1 부터 Depreacted
+     * 내가 작성한 리뷰 조회시, 삭제된 가게들을 반환하되, 삭제된 가게라고 표기해줘야하는 이슈에 대응하기 위함. (호환성을 유지하기 위한 API)
+     * use GET /api/v3/store/reviews/me
+     */
+    @Deprecated
+    @ApiOperation("[인증] 마이 페이지 - 내가 작성한 리뷰 목록을 스크롤 페이지네이션으로 조회합니다 (삭제된 가게 포함 X)")
+    @Auth
+    @GetMapping("/api/v2/store/reviews/me")
+    public ApiResponse<ReviewScrollResponse> retrieveMyStoreReviewsV2(@Valid RetrieveMyReviewsRequest request, @UserId Long userId) {
+        return ApiResponse.success(reviewRetrieveService.retrieveMyReviewsV2(request, userId));
     }
 
 }

--- a/threedollar-api/src/main/java/com/depromeet/threedollar/api/controller/store/StoreRetrieveController.java
+++ b/threedollar-api/src/main/java/com/depromeet/threedollar/api/controller/store/StoreRetrieveController.java
@@ -35,11 +35,24 @@ public class StoreRetrieveController {
         return ApiResponse.success(storeRetrieveService.getDetailStoreInfo(request));
     }
 
-    @ApiOperation("[인증] 마이페이지 - 내가 제보한 가게 목록들을 스크롤 페이지네이션으로 조회합니다")
+    @ApiOperation("[인증] 마이페이지 - 내가 제보한 가게 목록들을 스크롤 페이지네이션으로 조회합니다 (삭제된 가게 포함 O)")
     @Auth
-    @GetMapping("/api/v2/stores/me")
+    @GetMapping("/api/v3/stores/me")
     public ApiResponse<StoresScrollResponse> getMyStores(@Valid RetrieveMyStoresRequest request, @UserId Long userId) {
         return ApiResponse.success(storeRetrieveService.retrieveMyStores(request, userId));
+    }
+
+    /**
+     * v2.1.1 부터 Deprecated
+     * 내가 제보한 가게 조회시, 삭제된 가게들을 반환하되, 삭제된 가게라고 표기해줘야하는 이슈에 대응하기 위함. (호환성을 유지하기 위한 API)
+     * use GET /api/v3/stores/me
+     */
+    @Deprecated
+    @ApiOperation("[인증] 마이페이지 - 내가 제보한 가게 목록들을 스크롤 페이지네이션으로 조회합니다 (삭제된 가게 포함 X)")
+    @Auth
+    @GetMapping("/api/v2/stores/me")
+    public ApiResponse<StoresScrollResponse> getMyStoresV2(@Valid RetrieveMyStoresRequest request, @UserId Long userId) {
+        return ApiResponse.success(storeRetrieveService.retrieveMyStoresV2(request, userId));
     }
 
     /**

--- a/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/review/dto/response/ReviewDetailResponse.java
+++ b/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/review/dto/response/ReviewDetailResponse.java
@@ -20,17 +20,19 @@ public class ReviewDetailResponse extends AuditingTimeResponse {
     private String contents;
     private Long storeId;
     private String storeName;
+    private Boolean isDeletedStore;
     private UserInfoResponse user;
     private final List<MenuCategoryType> categories = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
-    private ReviewDetailResponse(Long reviewId, int rating, String contents, Long storeId, String storeName,
+    private ReviewDetailResponse(Long reviewId, int rating, String contents, Long storeId, String storeName, boolean isDeletedStore,
                                  UserInfoResponse user, List<MenuCategoryType> categories) {
         this.reviewId = reviewId;
         this.rating = rating;
         this.contents = contents;
         this.storeId = storeId;
         this.storeName = storeName;
+        this.isDeletedStore = isDeletedStore;
         this.user = user;
         this.categories.addAll(categories);
     }
@@ -42,6 +44,7 @@ public class ReviewDetailResponse extends AuditingTimeResponse {
             .contents(review.getContents())
             .storeId(review.getStoreId())
             .storeName(store.getName())
+            .isDeletedStore(store.isDeleted())
             .user(UserInfoResponse.of(review.getUserId(), review.getUserName(), review.getUserSocialType()))
             .categories(store.getMenuCategoriesSortedByCounts())
             .build();

--- a/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/store/StoreRetrieveService.java
+++ b/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/store/StoreRetrieveService.java
@@ -74,6 +74,16 @@ public class StoreRetrieveService {
 
     @Deprecated
     @Transactional(readOnly = true)
+    public StoresScrollResponse retrieveMyStoresV2(RetrieveMyStoresRequest request, Long userId) {
+        List<Store> storesWithNextCursor = storeRepository.findAllActiveByUserIdWithScroll(userId, request.getCursor(), request.getSize() + 1);
+        ScrollPaginationCollection<Store> scrollCollection = ScrollPaginationCollection.of(storesWithNextCursor, request.getSize());
+        VisitHistoriesCountCollection visitHistoryCountsCollection = findVisitHistoriesCountByStoreIds(scrollCollection.getItemsInCurrentScroll());
+        long totalElements = Objects.requireNonNullElseGet(request.getCachingTotalElements(), () -> storeRepository.findActiveCountsByUserId(userId));
+        return StoresScrollResponse.of(scrollCollection, visitHistoryCountsCollection, totalElements, request.getLatitude(), request.getLongitude());
+    }
+
+    @Deprecated
+    @Transactional(readOnly = true)
     public StoresGroupByDistanceResponse getNearStoresGroupByDistance(RetrieveStoreGroupByCategoryRequest request) {
         List<Store> nearStores = findNearCategoryStores(request.getMapLatitude(), request.getMapLongitude(), LIMIT_DISTANCE, request.getCategory());
         VisitHistoriesCountCollection visitHistoriesCountCollection = findVisitHistoriesCountByStoreIds(nearStores);

--- a/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/store/StoreService.java
+++ b/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/store/StoreService.java
@@ -32,7 +32,7 @@ public class StoreService {
     @Transactional
     public StoreInfoResponse addStore(AddStoreRequest request, Long userId) {
         Store store = storeRepository.save(request.toStore(userId));
-        return StoreInfoResponse.ofWithOutVisitsCount(store);
+        return StoreInfoResponse.ofZeroVisitCounts(store);
     }
 
     @Transactional
@@ -42,7 +42,7 @@ public class StoreService {
         store.updatePaymentMethods(request.getPaymentMethods());
         store.updateAppearanceDays(request.getAppearanceDays());
         store.updateMenu(request.toMenus(store));
-        return StoreInfoResponse.ofWithOutVisitsCount(store);
+        return StoreInfoResponse.ofZeroVisitCounts(store);
     }
 
     @Transactional

--- a/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/store/dto/response/StoreInfoResponse.java
+++ b/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/store/dto/response/StoreInfoResponse.java
@@ -23,9 +23,10 @@ public class StoreInfoResponse extends AuditingTimeResponse {
     private Integer distance;
     private final List<MenuCategoryType> categories = new ArrayList<>();
     private VisitHistoryInfoResponse visitHistory;
+    private Boolean isDeleted;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private StoreInfoResponse(Long storeId, double latitude, double longitude, String storeName, double rating, Integer distance, long existsVisitsCount, long notExistsVisitsCount) {
+    private StoreInfoResponse(Long storeId, double latitude, double longitude, String storeName, double rating, Integer distance, long existsVisitsCount, long notExistsVisitsCount, boolean isDeleted) {
         this.storeId = storeId;
         this.latitude = latitude;
         this.longitude = longitude;
@@ -33,6 +34,7 @@ public class StoreInfoResponse extends AuditingTimeResponse {
         this.rating = rating;
         this.distance = distance;
         this.visitHistory = VisitHistoryInfoResponse.of(existsVisitsCount, notExistsVisitsCount);
+        this.isDeleted = isDeleted;
     }
 
     public static StoreInfoResponse testInstance(int distance, double rating) {
@@ -42,7 +44,7 @@ public class StoreInfoResponse extends AuditingTimeResponse {
             .build();
     }
 
-    public static StoreInfoResponse of(Store store, double latitude, double longitude, long existsVisitsCount, long notExistsVisitsCount) {
+    public static StoreInfoResponse of(Store store, Double latitude, Double longitude, long existsVisitsCount, long notExistsVisitsCount) {
         StoreInfoResponse response = StoreInfoResponse.builder()
             .storeId(store.getId())
             .latitude(store.getLatitude())
@@ -52,29 +54,14 @@ public class StoreInfoResponse extends AuditingTimeResponse {
             .distance(LocationDistanceUtils.getDistance(latitude, longitude, store.getLatitude(), store.getLongitude()))
             .existsVisitsCount(existsVisitsCount)
             .notExistsVisitsCount(notExistsVisitsCount)
+            .isDeleted(store.isDeleted())
             .build();
         response.categories.addAll(store.getMenuCategoriesSortedByCounts());
         response.setBaseTime(store);
         return response;
     }
 
-    public static StoreInfoResponse of(Store store, long existsVisitsCount, long notExistsVisitsCount) {
-        StoreInfoResponse response = StoreInfoResponse.builder()
-            .storeId(store.getId())
-            .latitude(store.getLatitude())
-            .longitude(store.getLongitude())
-            .storeName(store.getName())
-            .rating(store.getRating())
-            .distance(null)
-            .existsVisitsCount(existsVisitsCount)
-            .notExistsVisitsCount(notExistsVisitsCount)
-            .build();
-        response.categories.addAll(store.getMenuCategoriesSortedByCounts());
-        response.setBaseTime(store);
-        return response;
-    }
-
-    public static StoreInfoResponse ofWithOutVisitsCount(Store store) {
+    public static StoreInfoResponse ofZeroVisitCounts(Store store) {
         StoreInfoResponse response = StoreInfoResponse.builder()
             .storeId(store.getId())
             .latitude(store.getLatitude())
@@ -84,6 +71,7 @@ public class StoreInfoResponse extends AuditingTimeResponse {
             .distance(null)
             .existsVisitsCount(0)
             .notExistsVisitsCount(0)
+            .isDeleted(store.isDeleted())
             .build();
         response.categories.addAll(store.getMenuCategoriesSortedByCounts());
         response.setBaseTime(store);

--- a/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/store/dto/response/StoresScrollResponse.java
+++ b/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/store/dto/response/StoresScrollResponse.java
@@ -49,11 +49,6 @@ public class StoresScrollResponse {
     }
 
     private static List<StoreInfoResponse> getContents(List<Store> stores, VisitHistoriesCountCollection collection, Double latitude, Double longitude) {
-        if (latitude == null || longitude == null) {
-            return stores.stream()
-                .map(store -> StoreInfoResponse.of(store, collection.getStoreExistsVisitsCount(store.getId()), collection.getStoreNotExistsVisitsCount(store.getId())))
-                .collect(Collectors.toList());
-        }
         return stores.stream()
             .map(store -> StoreInfoResponse.of(store, latitude, longitude,
                 collection.getStoreExistsVisitsCount(store.getId()), collection.getStoreNotExistsVisitsCount(store.getId())))

--- a/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/visit/dto/response/VisitHistoryWithStoreResponse.java
+++ b/threedollar-api/src/main/java/com/depromeet/threedollar/api/service/visit/dto/response/VisitHistoryWithStoreResponse.java
@@ -35,7 +35,7 @@ public class VisitHistoryWithStoreResponse extends AuditingTimeResponse {
             .visitHistoryId(visitHistory.getId())
             .type(visitHistory.getType())
             .dateOfVisit(visitHistory.getDateOfVisit())
-            .store(StoreInfoResponse.ofWithOutVisitsCount(store))
+            .store(StoreInfoResponse.ofZeroVisitCounts(store))
             .build();
         response.setBaseTime(visitHistory.getCreatedAt(), visitHistory.getUpdatedAt());
         return response;

--- a/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/review/ReviewControllerTest.java
+++ b/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/review/ReviewControllerTest.java
@@ -9,10 +9,14 @@ import com.depromeet.threedollar.api.service.review.dto.response.ReviewInfoRespo
 import com.depromeet.threedollar.api.service.review.dto.response.ReviewScrollResponse;
 import com.depromeet.threedollar.api.service.user.dto.response.UserInfoResponse;
 import com.depromeet.threedollar.application.common.dto.ApiResponse;
+import com.depromeet.threedollar.domain.domain.menu.MenuCategoryType;
+import com.depromeet.threedollar.domain.domain.menu.MenuCreator;
 import com.depromeet.threedollar.domain.domain.menu.MenuRepository;
 import com.depromeet.threedollar.domain.domain.review.Review;
 import com.depromeet.threedollar.domain.domain.review.ReviewCreator;
 import com.depromeet.threedollar.domain.domain.review.ReviewRepository;
+import com.depromeet.threedollar.domain.domain.store.Store;
+import com.depromeet.threedollar.domain.domain.store.StoreCreator;
 import com.depromeet.threedollar.domain.domain.store.StoreRepository;
 import com.depromeet.threedollar.domain.domain.user.UserSocialType;
 import org.junit.jupiter.api.*;
@@ -129,10 +133,10 @@ class ReviewControllerTest extends SetupStoreControllerTest {
             assertThat(response.getData().getNextCursor()).isEqualTo(review3.getId());
             assertThat(response.getData().getContents()).hasSize(2);
 
-            assertReviewInfoResponse(response.getData().getContents().get(0), review4.getId(), store.getId(), store.getName(), review4.getContents(), review4.getRating());
+            assertReviewDetailInfoResponse(response.getData().getContents().get(0), review4.getId(), store.getId(), store.getName(), review4.getContents(), review4.getRating());
             assertUserInfoResponse(response.getData().getContents().get(0).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
 
-            assertReviewInfoResponse(response.getData().getContents().get(1), review3.getId(), store.getId(), store.getName(), review3.getContents(), review3.getRating());
+            assertReviewDetailInfoResponse(response.getData().getContents().get(1), review3.getId(), store.getId(), store.getName(), review3.getContents(), review3.getRating());
             assertUserInfoResponse(response.getData().getContents().get(1).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
         }
 
@@ -155,10 +159,10 @@ class ReviewControllerTest extends SetupStoreControllerTest {
             assertThat(response.getData().getNextCursor()).isEqualTo(review2.getId());
             assertThat(response.getData().getContents()).hasSize(2);
 
-            assertReviewInfoResponse(response.getData().getContents().get(0), review3.getId(), store.getId(), store.getName(), review3.getContents(), review3.getRating());
+            assertReviewDetailInfoResponse(response.getData().getContents().get(0), review3.getId(), store.getId(), store.getName(), review3.getContents(), review3.getRating());
             assertUserInfoResponse(response.getData().getContents().get(0).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
 
-            assertReviewInfoResponse(response.getData().getContents().get(1), review2.getId(), store.getId(), store.getName(), review2.getContents(), review2.getRating());
+            assertReviewDetailInfoResponse(response.getData().getContents().get(1), review2.getId(), store.getId(), store.getName(), review2.getContents(), review2.getRating());
             assertUserInfoResponse(response.getData().getContents().get(1).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
         }
 
@@ -181,10 +185,10 @@ class ReviewControllerTest extends SetupStoreControllerTest {
             assertThat(response.getData().getNextCursor()).isEqualTo(review2.getId());
             assertThat(response.getData().getContents()).hasSize(2);
 
-            assertReviewInfoResponse(response.getData().getContents().get(0), review3.getId(), store.getId(), store.getName(), review3.getContents(), review3.getRating());
+            assertReviewDetailInfoResponse(response.getData().getContents().get(0), review3.getId(), store.getId(), store.getName(), review3.getContents(), review3.getRating());
             assertUserInfoResponse(response.getData().getContents().get(0).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
 
-            assertReviewInfoResponse(response.getData().getContents().get(1), review2.getId(), store.getId(), store.getName(), review2.getContents(), review2.getRating());
+            assertReviewDetailInfoResponse(response.getData().getContents().get(1), review2.getId(), store.getId(), store.getName(), review2.getContents(), review2.getRating());
             assertUserInfoResponse(response.getData().getContents().get(1).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
         }
 
@@ -207,10 +211,10 @@ class ReviewControllerTest extends SetupStoreControllerTest {
             assertThat(response.getData().getNextCursor()).isEqualTo(-1);
             assertThat(response.getData().getContents()).hasSize(2);
 
-            assertReviewInfoResponse(response.getData().getContents().get(0), review2.getId(), store.getId(), store.getName(), review2.getContents(), review2.getRating());
+            assertReviewDetailInfoResponse(response.getData().getContents().get(0), review2.getId(), store.getId(), store.getName(), review2.getContents(), review2.getRating());
             assertUserInfoResponse(response.getData().getContents().get(0).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
 
-            assertReviewInfoResponse(response.getData().getContents().get(1), review1.getId(), store.getId(), store.getName(), review1.getContents(), review1.getRating());
+            assertReviewDetailInfoResponse(response.getData().getContents().get(1), review1.getId(), store.getId(), store.getName(), review1.getContents(), review1.getRating());
             assertUserInfoResponse(response.getData().getContents().get(1).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
         }
 
@@ -233,7 +237,7 @@ class ReviewControllerTest extends SetupStoreControllerTest {
             assertThat(response.getData().getNextCursor()).isEqualTo(-1);
             assertThat(response.getData().getContents()).hasSize(1);
 
-            assertReviewInfoResponse(response.getData().getContents().get(0), review1.getId(), store.getId(), store.getName(), review1.getContents(), review1.getRating());
+            assertReviewDetailInfoResponse(response.getData().getContents().get(0), review1.getId(), store.getId(), store.getName(), review1.getContents(), review1.getRating());
             assertUserInfoResponse(response.getData().getContents().get(0).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
         }
 
@@ -254,6 +258,30 @@ class ReviewControllerTest extends SetupStoreControllerTest {
             assertThat(response.getData().getContents()).isEmpty();
         }
 
+        @Test
+        void 삭제된_가게인경우_없어진_가게라고_표시된다() throws Exception {
+            // given
+            Store deletedStore = StoreCreator.create(testUser.getId(), "원래 가게 이름");
+            deletedStore.addMenus(List.of(MenuCreator.create(deletedStore, "메뉴 이름", "가격", MenuCategoryType.BUNGEOPPANG)));
+            deletedStore.delete();
+            storeRepository.save(deletedStore);
+
+            Review review = ReviewCreator.create(deletedStore.getId(), testUser.getId(), "너무 맛있어요", 5);
+            reviewRepository.save(review);
+
+            RetrieveMyReviewsRequest request = RetrieveMyReviewsRequest.testInstance(2, null, null);
+
+            // when
+            ApiResponse<ReviewScrollResponse> response = reviewMockApiCaller.retrieveMyStoreReviews(request, token, 200);
+
+            // then
+            assertThat(response.getData().getTotalElements()).isEqualTo(1);
+            assertThat(response.getData().getNextCursor()).isEqualTo(-1);
+            assertThat(response.getData().getContents()).hasSize(1);
+            assertReviewDetailInfoResponse(response.getData().getContents().get(0), review.getId(), deletedStore.getId(), Store.DELETE_STORE_NAME, review.getContents(), review.getRating());
+            assertUserInfoResponse(response.getData().getContents().get(0).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
+        }
+
     }
 
     private void assertUserInfoResponse(UserInfoResponse user, Long id, String name, UserSocialType socialType) {
@@ -268,7 +296,7 @@ class ReviewControllerTest extends SetupStoreControllerTest {
         assertThat(response.getRating()).isEqualTo(rating);
     }
 
-    private void assertReviewInfoResponse(ReviewDetailResponse response, Long reviewId, Long storeId, String storeName, String contents, int rating) {
+    private void assertReviewDetailInfoResponse(ReviewDetailResponse response, Long reviewId, Long storeId, String storeName, String contents, int rating) {
         assertThat(response.getStoreId()).isEqualTo(storeId);
         assertThat(response.getStoreName()).isEqualTo(storeName);
         assertThat(response.getContents()).isEqualTo(contents);

--- a/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/review/ReviewControllerTest.java
+++ b/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/review/ReviewControllerTest.java
@@ -282,6 +282,29 @@ class ReviewControllerTest extends SetupStoreControllerTest {
             assertUserInfoResponse(response.getData().getContents().get(0).getUser(), testUser.getId(), testUser.getName(), testUser.getSocialType());
         }
 
+        @Deprecated
+        @Test
+        void V2버전에서는_삭제된_가게인경우_해당_리뷰는_조회되지_않는다() throws Exception {
+            // given
+            Store deletedStore = StoreCreator.create(testUser.getId(), "원래 가게 이름");
+            deletedStore.addMenus(List.of(MenuCreator.create(deletedStore, "메뉴 이름", "가격", MenuCategoryType.BUNGEOPPANG)));
+            deletedStore.delete();
+            storeRepository.save(deletedStore);
+
+            Review review = ReviewCreator.create(deletedStore.getId(), testUser.getId(), "너무 맛있어요", 5);
+            reviewRepository.save(review);
+
+            RetrieveMyReviewsRequest request = RetrieveMyReviewsRequest.testInstance(2, null, null);
+
+            // when
+            ApiResponse<ReviewScrollResponse> response = reviewMockApiCaller.retrieveMyStoreReviewsV2(request, token, 200);
+
+            // then
+            assertThat(response.getData().getTotalElements()).isEqualTo(0);
+            assertThat(response.getData().getNextCursor()).isEqualTo(-1);
+            assertThat(response.getData().getContents()).isEmpty();
+        }
+
     }
 
     private void assertUserInfoResponse(UserInfoResponse user, Long id, String name, UserSocialType socialType) {

--- a/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/review/ReviewMockApiCaller.java
+++ b/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/review/ReviewMockApiCaller.java
@@ -76,6 +76,25 @@ class ReviewMockApiCaller extends MockMvcUtils {
     }
 
     public ApiResponse<ReviewScrollResponse> retrieveMyStoreReviews(RetrieveMyReviewsRequest request, String token, int expectedStatus) throws Exception {
+        MockHttpServletRequestBuilder builder = get("/api/v3/store/reviews/me")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("size", String.valueOf(request.getSize()))
+            .param("cursor", request.getCursor() == null ? null : String.valueOf(request.getCursor()))
+            .param("cachingTotalElements", request.getCachingTotalElements() == null ? null : String.valueOf(request.getCachingTotalElements()));
+
+        return objectMapper.readValue(
+            mockMvc.perform(builder)
+                .andExpect(status().is(expectedStatus))
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8), new TypeReference<>() {
+            }
+        );
+    }
+
+    @Deprecated
+    public ApiResponse<ReviewScrollResponse> retrieveMyStoreReviewsV2(RetrieveMyReviewsRequest request, String token, int expectedStatus) throws Exception {
         MockHttpServletRequestBuilder builder = get("/api/v2/store/reviews/me")
             .header(HttpHeaders.AUTHORIZATION, token)
             .param("size", String.valueOf(request.getSize()))

--- a/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/store/StoreRetrieveControllerTest.java
+++ b/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/store/StoreRetrieveControllerTest.java
@@ -733,6 +733,27 @@ class StoreRetrieveControllerTest extends SetupUserControllerTest {
             assertThat(response.getData().getContents().get(0).getCategories()).containsExactlyInAnyOrder(MenuCategoryType.BUNGEOPPANG);
         }
 
+        @Deprecated
+        @Test
+        void V2버전에서는_내가_작성한_가게_목록_조회시_삭제된_가게는_조회되지_않는다() throws Exception {
+            // given
+            Store store = StoreCreator.create(testUser.getId(), "가게 이름", 34, 124);
+            Menu menu = MenuCreator.create(store, "메뉴", "가격", MenuCategoryType.BUNGEOPPANG);
+            store.addMenus(List.of(menu));
+            store.delete();
+            storeRepository.save(store);
+
+            RetrieveMyStoresRequest request = RetrieveMyStoresRequest.testInstance(2, null, null, null, null);
+
+            // when
+            ApiResponse<StoresScrollResponse> response = storeRetrieveMockApiCaller.getMyStoresV2(request, token, 200);
+
+            // then
+            assertThat(response.getData().getTotalElements()).isEqualTo(0);
+            assertThat(response.getData().getNextCursor()).isEqualTo(-1);
+            assertThat(response.getData().getContents()).isEmpty();
+        }
+
         @Test
         void 내가_작성한_가게_목록_조회시_방문_성공_및_실패_횟수와_가게_인증_여부를_반환한다() throws Exception {
             // given

--- a/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/store/StoreRetrieveControllerTest.java
+++ b/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/store/StoreRetrieveControllerTest.java
@@ -710,10 +710,11 @@ class StoreRetrieveControllerTest extends SetupUserControllerTest {
         }
 
         @Test
-        void 내가_작성한_가게_목록_조회시_삭제된_가게는_조회되지_않는다() throws Exception {
+        void 내가_작성한_가게_목록_조회시_삭제된_가게는_삭제된_가게로_조회된다() throws Exception {
             // given
             Store store = StoreCreator.create(testUser.getId(), "가게 이름", 34, 124);
-            store.addMenus(List.of(MenuCreator.create(store, "메뉴", "가격", MenuCategoryType.BUNGEOPPANG)));
+            Menu menu = MenuCreator.create(store, "메뉴", "가격", MenuCategoryType.BUNGEOPPANG);
+            store.addMenus(List.of(menu));
             store.delete();
             storeRepository.save(store);
 
@@ -723,9 +724,13 @@ class StoreRetrieveControllerTest extends SetupUserControllerTest {
             ApiResponse<StoresScrollResponse> response = storeRetrieveMockApiCaller.getMyStores(request, token, 200);
 
             // then
-            assertThat(response.getData().getTotalElements()).isEqualTo(0);
+            assertThat(response.getData().getTotalElements()).isEqualTo(1);
             assertThat(response.getData().getNextCursor()).isEqualTo(-1);
-            assertThat(response.getData().getContents()).isEmpty();
+            assertThat(response.getData().getContents()).hasSize(1);
+            assertStoreInfoResponse(response.getData().getContents().get(0), store.getId(), store.getLatitude(), store.getLongitude(), Store.DELETE_STORE_NAME, store.getRating());
+
+            assertThat(response.getData().getContents().get(0).getCategories()).hasSize(1);
+            assertThat(response.getData().getContents().get(0).getCategories()).containsExactlyInAnyOrder(MenuCategoryType.BUNGEOPPANG);
         }
 
         @Test
@@ -1113,8 +1118,8 @@ class StoreRetrieveControllerTest extends SetupUserControllerTest {
         assertThat(response.getRating()).isEqualTo(rating);
     }
 
-    private void assertStoreInfoResponse(StoreInfoResponse response, Long id, Double latitude, Double longitude, String name, double rating) {
-        assertThat(response.getStoreId()).isEqualTo(id);
+    private void assertStoreInfoResponse(StoreInfoResponse response, Long storeId, Double latitude, Double longitude, String name, double rating) {
+        assertThat(response.getStoreId()).isEqualTo(storeId);
         assertThat(response.getLatitude()).isEqualTo(latitude);
         assertThat(response.getLongitude()).isEqualTo(longitude);
         assertThat(response.getStoreName()).isEqualTo(name);

--- a/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/store/StoreRetrieveMockApiCaller.java
+++ b/threedollar-api/src/test/java/com/depromeet/threedollar/api/controller/store/StoreRetrieveMockApiCaller.java
@@ -68,6 +68,26 @@ class StoreRetrieveMockApiCaller extends MockMvcUtils {
     }
 
     public ApiResponse<StoresScrollResponse> getMyStores(RetrieveMyStoresRequest request, String token, int expectedStatus) throws Exception {
+        MockHttpServletRequestBuilder builder = get("/api/v3/stores/me")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("size", String.valueOf(request.getSize()))
+            .param("cursor", request.getCursor() == null ? null : String.valueOf(request.getCursor()))
+            .param("cachingTotalElements", request.getCachingTotalElements() == null ? null : String.valueOf(request.getCachingTotalElements()))
+            .param("latitude", request.getLatitude() == null ? null : String.valueOf(request.getLatitude()))
+            .param("longitude", request.getLongitude() == null ? null : String.valueOf(request.getLongitude()));
+
+        return objectMapper.readValue(
+            mockMvc.perform(builder)
+                .andExpect(status().is(expectedStatus))
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8), new TypeReference<>() {
+            }
+        );
+    }
+
+    public ApiResponse<StoresScrollResponse> getMyStoresV2(RetrieveMyStoresRequest request, String token, int expectedStatus) throws Exception {
         MockHttpServletRequestBuilder builder = get("/api/v2/stores/me")
             .header(HttpHeaders.AUTHORIZATION, token)
             .param("size", String.valueOf(request.getSize()))

--- a/threedollar-api/src/test/java/com/depromeet/threedollar/api/service/store/dto/response/StoreInfoResponseTest.java
+++ b/threedollar-api/src/test/java/com/depromeet/threedollar/api/service/store/dto/response/StoreInfoResponseTest.java
@@ -1,0 +1,75 @@
+package com.depromeet.threedollar.api.service.store.dto.response;
+
+import com.depromeet.threedollar.domain.domain.menu.MenuCategoryType;
+import com.depromeet.threedollar.domain.domain.menu.MenuCreator;
+import com.depromeet.threedollar.domain.domain.store.Store;
+import com.depromeet.threedollar.domain.domain.store.StoreCreator;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class StoreInfoResponseTest {
+
+    @Test
+    void 삭제된_가게인경우_삭제된_가게_이름으로_표기된다() {
+        // given
+        Store store = StoreCreator.create(10000L, "가게 이름");
+        store.addMenus(List.of(
+            MenuCreator.create(store, "붕어빵", "천원", MenuCategoryType.BUNGEOPPANG),
+            MenuCreator.create(store, "달고나", "2천원", MenuCategoryType.DALGONA)
+        ));
+        store.delete();
+
+        // when
+        StoreInfoResponse response = StoreInfoResponse.of(store, null, null, 0, 0);
+
+        // then
+        assertAll(
+            () -> assertThat(response.getStoreName()).isEqualTo(Store.DELETE_STORE_NAME),
+            () -> assertThat(response.getIsDeleted()).isTrue()
+        );
+    }
+
+    @Test
+    void 삭제된_가게인경우_이름을_제외한_나머지_정보들을_정상_반환한다() {
+        // given
+        Store store = StoreCreator.create(10000L, "가게 이름");
+        store.addMenus(List.of(
+            MenuCreator.create(store, "붕어빵", "천원", MenuCategoryType.BUNGEOPPANG),
+            MenuCreator.create(store, "달고나", "2천원", MenuCategoryType.DALGONA)
+        ));
+        store.delete();
+
+        // when
+        StoreInfoResponse response = StoreInfoResponse.of(store, null, null, 0, 0);
+
+        // then
+        assertAll(
+            () -> assertThat(response.getStoreId()).isEqualTo(store.getId()),
+            () -> assertThat(response.getRating()).isEqualTo(store.getRating()),
+            () -> assertThat(response.getLatitude()).isEqualTo(store.getLatitude()),
+            () -> assertThat(response.getLongitude()).isEqualTo(store.getLongitude()),
+            () -> assertThat(response.getCategories()).containsExactlyInAnyOrder(MenuCategoryType.BUNGEOPPANG, MenuCategoryType.DALGONA)
+        );
+    }
+
+    @Test
+    void 따로_현재_위도와_경도를_넘기지_않는경우_거리는_0으로_표시된다() {
+        // given
+        Store store = StoreCreator.create(10000L, "가게 이름");
+        store.addMenus(List.of(
+            MenuCreator.create(store, "붕어빵", "천원", MenuCategoryType.BUNGEOPPANG),
+            MenuCreator.create(store, "달고나", "2천원", MenuCategoryType.DALGONA)
+        ));
+
+        // when
+        StoreInfoResponse response = StoreInfoResponse.of(store, null, null, 0, 0);
+
+        // then
+        assertThat(response.getDistance()).isEqualTo(0);
+    }
+
+}

--- a/threedollar-common/src/main/java/com/depromeet/threedollar/common/utils/LocationDistanceUtils.java
+++ b/threedollar-common/src/main/java/com/depromeet/threedollar/common/utils/LocationDistanceUtils.java
@@ -10,7 +10,10 @@ public class LocationDistanceUtils {
      * 두 위도/경도간의 거리를 계산해주는 유틸성 메소드.
      * 일단 기존의 프로젝트의 방법 적용하였음.
      */
-    public static int getDistance(double sourceLatitude, double sourceLongitude, double targetLatitude, double targetLongitude) {
+    public static int getDistance(Double sourceLatitude, Double sourceLongitude, Double targetLatitude, Double targetLongitude) {
+        if (sourceLatitude == null || sourceLongitude == null || targetLatitude == null || targetLongitude == null) {
+            return 0;
+        }
         double theta = sourceLongitude - targetLongitude;
         double dist = Math.sin(deg2rad(sourceLatitude)) * Math.sin(deg2rad(targetLatitude))
             + Math.cos(deg2rad(sourceLatitude)) * Math.cos(deg2rad(targetLatitude)) * Math.cos(deg2rad(theta));

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/review/repository/ReviewRepositoryCustom.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/review/repository/ReviewRepositoryCustom.java
@@ -13,8 +13,14 @@ public interface ReviewRepositoryCustom {
 
     long findCountsByUserId(Long userId);
 
+    @Deprecated
+    long findActiveCountsByUserId(Long userId);
+
     List<ReviewWithWriterProjection> findAllWithCreatorByStoreId(Long storeId);
 
     List<ReviewWithWriterProjection> findAllByUserIdWithScroll(Long userId, Long lastStoreId, int size);
+
+    @Deprecated
+    List<ReviewWithWriterProjection> findAllActiveByUserIdWithScroll(Long userId, Long lastStoreId, int size);
 
 }

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/review/repository/ReviewRepositoryCustomImpl.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/review/repository/ReviewRepositoryCustomImpl.java
@@ -4,7 +4,6 @@ import com.depromeet.threedollar.domain.domain.review.Review;
 import com.depromeet.threedollar.domain.domain.review.ReviewStatus;
 import com.depromeet.threedollar.domain.domain.review.projection.QReviewWithWriterProjection;
 import com.depromeet.threedollar.domain.domain.review.projection.ReviewWithWriterProjection;
-import com.depromeet.threedollar.domain.domain.store.StoreStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +11,9 @@ import lombok.RequiredArgsConstructor;
 import javax.persistence.LockModeType;
 import java.util.List;
 
+import static com.depromeet.threedollar.domain.domain.review.QReview.review;
 import static com.depromeet.threedollar.domain.domain.store.QStore.store;
 import static com.depromeet.threedollar.domain.domain.user.QUser.user;
-import static com.depromeet.threedollar.domain.domain.review.QReview.review;
 
 @RequiredArgsConstructor
 public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
@@ -51,8 +50,7 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
             .innerJoin(store).on(review.storeId.eq(store.id))
             .where(
                 review.userId.eq(userId),
-                review.status.eq(ReviewStatus.POSTED),
-                store.status.eq(StoreStatus.ACTIVE)
+                review.status.eq(ReviewStatus.POSTED)
             )
             .fetchCount();
     }
@@ -87,7 +85,6 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
             .where(
                 review.userId.eq(userId),
                 review.status.eq(ReviewStatus.POSTED),
-                store.status.eq(StoreStatus.ACTIVE),
                 lessThanId(lastStoreId)
             )
             .orderBy(review.id.desc())

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/store/Store.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/store/Store.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
 )
 public class Store extends AuditingTimeEntity {
 
+    public static final String DELETE_STORE_NAME = "삭제된 가게입니다";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -196,6 +198,17 @@ public class Store extends AuditingTimeEntity {
 
     public double getRating() {
         return MathUtils.round(rating, 1);
+    }
+
+    public String getName() {
+        if (isDeleted()) {
+            return DELETE_STORE_NAME;
+        }
+        return this.name;
+    }
+
+    public boolean isDeleted() {
+        return this.status.equals(StoreStatus.DELETED);
     }
 
 }

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/store/repository/StoreRepositoryCustom.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/store/repository/StoreRepositoryCustom.java
@@ -13,9 +13,15 @@ public interface StoreRepositoryCustom {
 
     long findCountsByUserId(Long userId);
 
+    @Deprecated
+    long findActiveCountsByUserId(Long userId);
+
     List<Store> findAllWithScroll(Long lastStoreId, int size);
 
     List<Store> findAllByUserIdWithScroll(Long userId, Long lastStoreId, int size);
+
+    @Deprecated
+    List<Store> findAllActiveByUserIdWithScroll(Long userId, Long lastStoreId, int size);
 
     List<Store> findAllByIds(List<Long> storeIds);
 

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/store/repository/StoreRepositoryCustomImpl.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/store/repository/StoreRepositoryCustomImpl.java
@@ -56,8 +56,7 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             .from(store)
             .innerJoin(menu).on(menu.store.id.eq(store.id))
             .where(
-                store.userId.eq(userId),
-                store.status.eq(StoreStatus.ACTIVE)
+                store.userId.eq(userId)
             )
             .fetchCount();
     }
@@ -89,7 +88,6 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             .innerJoin(menu).on(menu.store.id.eq(store.id))
             .where(
                 store.userId.eq(userId),
-                store.status.eq(StoreStatus.ACTIVE),
                 lessThanId(lastStoreId)
             )
             .orderBy(store.id.desc())

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/store/repository/StoreRepositoryCustomImpl.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/store/repository/StoreRepositoryCustomImpl.java
@@ -61,6 +61,19 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             .fetchCount();
     }
 
+    @Deprecated
+    @Override
+    public long findActiveCountsByUserId(Long userId) {
+        return queryFactory.select(store.id).distinct()
+            .from(store)
+            .innerJoin(menu).on(menu.store.id.eq(store.id))
+            .where(
+                store.userId.eq(userId),
+                store.status.eq(StoreStatus.ACTIVE)
+            )
+            .fetchCount();
+    }
+
     @Override
     public List<Store> findAllWithScroll(Long lastStoreId, int size) {
         List<Long> storeIds = queryFactory.select(store.id).distinct()
@@ -88,6 +101,24 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             .innerJoin(menu).on(menu.store.id.eq(store.id))
             .where(
                 store.userId.eq(userId),
+                lessThanId(lastStoreId)
+            )
+            .orderBy(store.id.desc())
+            .limit(size)
+            .fetch();
+
+        return findAllByIds(storeIds);
+    }
+
+    @Deprecated
+    @Override
+    public List<Store> findAllActiveByUserIdWithScroll(Long userId, Long lastStoreId, int size) {
+        List<Long> storeIds = queryFactory.select(store.id).distinct()
+            .from(store)
+            .innerJoin(menu).on(menu.store.id.eq(store.id))
+            .where(
+                store.userId.eq(userId),
+                store.status.eq(StoreStatus.ACTIVE),
                 lessThanId(lastStoreId)
             )
             .orderBy(store.id.desc())

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/visit/repository/VisitHistoryRepositoryCustomImpl.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/domain/visit/repository/VisitHistoryRepositoryCustomImpl.java
@@ -1,6 +1,5 @@
 package com.depromeet.threedollar.domain.domain.visit.repository;
 
-import com.depromeet.threedollar.domain.domain.store.StoreStatus;
 import com.depromeet.threedollar.domain.domain.visit.VisitHistory;
 import com.depromeet.threedollar.domain.domain.visit.projection.QVisitHistoryWithCounts;
 import com.depromeet.threedollar.domain.domain.visit.projection.QVisitHistoryWithUserProjection;
@@ -14,9 +13,9 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static com.depromeet.threedollar.domain.domain.menu.QMenu.menu;
-import static com.depromeet.threedollar.domain.domain.visit.QVisitHistory.visitHistory;
-import static com.depromeet.threedollar.domain.domain.user.QUser.user;
 import static com.depromeet.threedollar.domain.domain.store.QStore.store;
+import static com.depromeet.threedollar.domain.domain.user.QUser.user;
+import static com.depromeet.threedollar.domain.domain.visit.QVisitHistory.visitHistory;
 
 @RequiredArgsConstructor
 public class VisitHistoryRepositoryCustomImpl implements VisitHistoryRepositoryCustom {
@@ -63,8 +62,7 @@ public class VisitHistoryRepositoryCustomImpl implements VisitHistoryRepositoryC
             .innerJoin(store.menus, menu).fetchJoin()
             .where(
                 visitHistory.userId.eq(userId),
-                lessThanId(lastHistoryId),
-                store.status.eq(StoreStatus.ACTIVE)
+                lessThanId(lastHistoryId)
             )
             .orderBy(visitHistory.id.desc())
             .limit(size)


### PR DESCRIPTION
### 변경 사항
[마이페이지] 내가 제보한 가게 및 내가 등록한 리뷰 목록을 조회하는 API

### AS-IS 
- 삭제된 가게인경우 마이페이지 목록에 아예 포함되지 않음.

### TO-BE
- 삭제된 가게인경우 마이페이지 목록에 보여지지만, 삭제된 가게라고 표기해줘야함.

### 방법
기존의 앱 호환성을 위해서 새로운 API를 만들고, 기존 API는 Deprecated 시킴.
- 기존 버전에서 삭제된 가게들이 마이페이지 목록에 그냥 보이는 현상? 방지
- AOS쪽에서 따로 404에러 핸들링이 안되어있는 상황이라, 삭제된 가게 조회시 크래시 발생 가능성 여부 존재
